### PR TITLE
k3d version hot-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,20 @@ Output attributes are accessible via `id`, e.g.:
 
 For more details see: [Multi Cluster on isolated networks](#multi-cluster-on-isolated-networks)
 
+### Version mapping
+K3d doesn't guarantee backward compatibility. To avoid potential issues due to usage the latest versions, the k3d, k3s 
+versions are hard-coded.
+
+| k3d-action |   k3d   |           k3s           |
+|:----------:|:-------:|:-----------------------:|
+| v1.1.0     |  [v3.4.0](https://github.com/rancher/k3d/releases/tag/v3.4.0) | [rancher/k3s:v1.20.2-k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.20.2%2Bk3s1)|
+
+
 ## Single Cluster
 Although AbsaOSS/k3d-action strongly supports multi-cluster. Single cluster scenarios are very popular. The minimum single-cluster 
 configuration looks like this :
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create Single Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -72,7 +81,7 @@ k3d creates a cluster with one worker node (with [traefik](https://traefik.io/) 
 default load-balancer node. In real scenarios you might prefer to do some port mapping and disable default load balancer. 
 Such an action would look like this:
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create Single Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -98,7 +107,7 @@ manually.
 ### Multi Cluster on default network
 ```yaml
       - uses: actions/checkout@v2
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 1st Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -109,7 +118,7 @@ manually.
             --agents 3
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 2nd Cluster"
         with:
           cluster-name: "test-cluster-2"
@@ -129,7 +138,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
 
 ### Multi Cluster on isolated networks
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 1st Cluster in 172.20.0.0/24"
         id: test-cluster-1
         with:
@@ -144,7 +153,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 2nd Cluster in 172.20.1.0/24"
         id: test-cluster-2
         with:
@@ -177,7 +186,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
 [Source](./.github/workflows/multi-cluster-on-isolated-networks.yaml)
 ### Two pairs of clusters on two isolated networks
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 1st Cluster in 172.20.0.0/24"
         with:
           cluster-name: "test-cluster-1-a"
@@ -188,7 +197,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 2nd Cluster in 172.20.0.0/24"
         with:
           cluster-name: "test-cluster-2-a"
@@ -198,7 +207,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 1st Cluster in 172.20.1.0/24"
         with:
           cluster-name: "test-cluster-1-b"
@@ -209,7 +218,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 2nd Cluster in 172.20.1.0/24"
         with:
           cluster-name: "test-cluster-2-b"
@@ -239,7 +248,7 @@ Example below demonstrates how to interact with default docker registry:
 
 ### Single Cluster With Private Registry
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         id: single-cluster
         name: "Create single Cluster with Registry"
         with:
@@ -260,7 +269,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
 The similar as previous example but injecting default registry into multiple clusters. It should be noted that the registry 
 is shared across clusters, so you don't have to push the same image several times. 
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 1st Cluster in 172.20.0.0/24 with Registry"
         with:
           cluster-name: "test-cluster-1-a"
@@ -271,7 +280,7 @@ is shared across clusters, so you don't have to push the same image several time
             --agents 1
             --no-lb
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 2nd Cluster in 172.20.0.0/24 with Registry"
         with:
           cluster-name: "test-cluster-2-a"
@@ -281,7 +290,7 @@ is shared across clusters, so you don't have to push the same image several time
             --agents 1
             --no-lb
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 1st Cluster in 172.20.1.0/24 with Registry"
         with:
           cluster-name: "test-cluster-1-b"
@@ -292,7 +301,7 @@ is shared across clusters, so you don't have to push the same image several time
             --agents 1
             --no-lb
 
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         name: "Create 2nd Cluster in 172.20.1.0/24 with Registry"
         with:
           cluster-name: "test-cluster-2-b"
@@ -309,7 +318,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
 In some very special cases is default registry, not enough for you. From some reason you need to test against secured 
 registry or must change hard-coded port `5000`.  For that reason `override-registry-config-path` attribute exists.
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.0.0
+      - uses: AbsaOSS/k3d-action@v1.1.0
         id: single-cluster
         name: "Create single Cluster with Registry"
         with:

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,8 @@ CYAN=
 RED=
 NC=
 K3D_URL=https://raw.githubusercontent.com/rancher/k3d/main/install.sh
+K3D_VERSION=v3.4.0
+K3S_VERSION=docker.io/rancher/k3s:v1.20.2-k3s1
 DEFAULT_NETWORK=k3d-action-bridge-network
 DEFAULT_SUBNET=172.16.0.0/24
 NOT_FOUND=k3d-not-found-network
@@ -105,11 +107,11 @@ deploy(){
     echo "::set-output name=network::$network"
     echo "::set-output name=subnet-CIDR::$subnet"
 
-    echo -e "${YELLOW}Downloading ${CYAN}k3d ${NC}see: ${K3D_URL}"
-    curl --silent --fail ${K3D_URL} | bash
+    echo -e "${YELLOW}Downloading ${CYAN}k3d@${K3D_VERSION} ${NC}see: ${K3D_URL}"
+    curl --silent --fail ${K3D_URL} | TAG=${K3D_VERSION} bash
 
     echo -e "\existing_network${YELLOW}Deploy cluster ${CYAN}$name ${NC}"
-    eval "k3d cluster create $name --wait $arguments --network $network $registryArg"
+    eval "k3d cluster create $name --wait $arguments --image ${K3S_VERSION} --network $network $registryArg"
 }
 
 registry(){


### PR DESCRIPTION
K3d doesn't guarantee backward compatibility. To avoid potential issues due to usage the latest versions, the k3d, k3s 
versions are hard-coded.
 - k3d version `v3.4.0` (pre latest)
 - k3s version `k3s:v1.20.2-k3s1` (currently latest)
 - bump version to `k3d-action@v1.1.0` in documentation, alter version mapping table

following steps:
 - release v1.1.0
 - bump our projects to v1.1.0
 - k3d@v4.0.0 support will be implemented later (issues exist)