### PR TITLE
[Feature] migration to k3d v4.2.0 registry

### DIFF
--- a/.github/workflows/multi-cluster-registry.yaml
+++ b/.github/workflows/multi-cluster-registry.yaml
@@ -46,3 +46,5 @@ jobs:
           kubectl get nodes -o wide
       - name: Network
         run: docker network inspect k3d-action-bridge-network
+      - name: Test registry
+        run: ./run.sh test-registry

--- a/.github/workflows/multi-cluster-two-piars-registry-shared.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry-shared.yaml
@@ -1,10 +1,10 @@
-name: Multi cluster; two pairs of clusters on two isolated networks with registry
+name: Multi cluster; two pairs of clusters on two isolated networks with shared registry
 
 on:
   [workflow_dispatch, push]
 jobs:
   k3d-multicluster-demo:
-    name: Two pairs of clusters on two isolated networks with registry
+    name: Two pairs of clusters on two isolated networks with shared registry
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +16,6 @@ jobs:
           network: "nw01"
           subnet-CIDR: "172.20.0.0/24"
           use-default-registry: true
-          registry-port: 5001
           args: >-
             --agents 1
             --no-lb
@@ -28,8 +27,6 @@ jobs:
         with:
           cluster-name: "test-cluster-2-a"
           network: "nw01"
-          use-default-registry: true
-          registry-port: 5001
           args: >-
             --agents 1
             --no-lb
@@ -42,8 +39,6 @@ jobs:
           cluster-name: "test-cluster-1-b"
           network: "nw02"
           subnet-CIDR: "172.20.1.0/24"
-          use-default-registry: true
-          registry-port: 5002
           args: >-
             --agents 1
             --no-lb
@@ -55,8 +50,6 @@ jobs:
         with:
           cluster-name: "test-cluster-2-b"
           network: "nw02"
-          use-default-registry: true
-          registry-port: 5002
           args: >-
             --agents 1
             --no-lb
@@ -97,10 +90,5 @@ jobs:
 
       - name: Test registry nw01
         env:
-          REGISTRY_PORT: 5001
-        run: ./run.sh test-registry
-
-      - name: Test registry nw02
-        env:
-          REGISTRY_PORT: 5002
+          REGISTRY_PORT: 5000
         run: ./run.sh test-registry

--- a/.github/workflows/single-cluster-registry.yaml
+++ b/.github/workflows/single-cluster-registry.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           cluster-name: "test-cluster-1"
           use-default-registry: true
+          registry-port: 5001
           args: >-
             --agents 1
             --no-lb
@@ -32,4 +33,8 @@ jobs:
           kubectl get nodes -o wide
       - name: Network
         run: docker network inspect k3d-action-bridge-network
+      - name: Test registry
+        env:
+          REGISTRY_PORT: 5001
+        run: ./run.sh test-registry
 

--- a/.github/workflows/single-cluster.yaml
+++ b/.github/workflows/single-cluster.yaml
@@ -34,4 +34,3 @@ jobs:
           kubectl get nodes -o wide
       - name: Network
         run: docker network inspect k3d-action-bridge-network
-

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # ...even if they are in subdirectories
 !*/
+
+# except gitignore
+/**/.gitignore

--- a/action.yaml
+++ b/action.yaml
@@ -22,8 +22,8 @@ inputs:
     description: "(Optional) Autogenerate docker registry accessible from the cluster."
     required: false
     default: "false"
-  override-registry-config-path:
-    description: "(Optional) Path to custom registry configuration file. Variable requires USE_DEFAULT_REGISTRY to be true."
+  registry-port:
+    description: "(Optional) Registry port. Default value 5000."
     required: false
 outputs:
   network:
@@ -44,4 +44,4 @@ runs:
         NETWORK: ${{ inputs.network }}
         SUBNET_CIDR: ${{ inputs.subnet-CIDR }}
         USE_DEFAULT_REGISTRY: ${{ inputs.use-default-registry }}
-        OVERRIDE_REGISTRY_CONFIG_PATH: ${{ inputs.override-registry-config-path }}
+        REGISTRY_PORT: ${{ inputs.registry-port }}

--- a/run.sh
+++ b/run.sh
@@ -10,13 +10,13 @@ CYAN=
 RED=
 NC=
 K3D_URL=https://raw.githubusercontent.com/rancher/k3d/main/install.sh
-K3D_VERSION=v3.4.0
+K3D_VERSION=v4.2.0
 K3S_VERSION=docker.io/rancher/k3s:v1.20.2-k3s1
 DEFAULT_NETWORK=k3d-action-bridge-network
 DEFAULT_SUBNET=172.16.0.0/24
+DEFAULT_REGISTRY_PORT=5000
 NOT_FOUND=k3d-not-found-network
-REGISTRY_LOCAL=registry.local
-REGISTRY_CONFIG_PATH="$(pwd)/registries-local.yaml"
+REGISTRY_LOCAL="registry-localhost"
 
 #######################
 #
@@ -29,6 +29,7 @@ usage(){
   Usage: $(basename "$0") <COMMAND>
   Commands:
       deploy            deploy custom k3d cluster
+      test-registry     test container registry
 
   Environment variables:
       deploy
@@ -45,11 +46,10 @@ usage(){
                         USE_DEFAULT_REGISTRY (Optional) If not set than default false. If true provides local docker registry
                                               registry.localhost:5000 without TLS and authentication.
 
-                        OVERRIDE_REGISTRY_CONFIG_PATH (Optional) Path to custom registry configuration file.
-                                              see: https://rancher.com/docs/k3s/latest/en/installation/private-registry/#mirrors
-                                              Variable requires USE_DEFAULT_REGISTRY to be true.
+                        REGISTRY_PORT (Optional) Registry port. Default value 5000.
 
-
+    test-registry
+                        REGISTRY_PORT (Optional) Registry port. Default value 5000.
 EOF
 }
 
@@ -64,8 +64,14 @@ deploy(){
     local arguments=${ARGS:-}
     local network=${NETWORK:-$DEFAULT_NETWORK}
     local subnet=${SUBNET_CIDR:-$DEFAULT_SUBNET}
+    local registryName="${network}-${REGISTRY_LOCAL}"
     local registry=${USE_DEFAULT_REGISTRY:-}
+    local registryPort=${REGISTRY_PORT:-$DEFAULT_REGISTRY_PORT}
     local registryArg
+
+    if [[ -z "${CLUSTER_NAME}" ]]; then
+      panic "CLUSTER_NAME must be set"
+    fi
 
     existing_network=$(docker network list | awk '   {print $2 }' | grep -w "^$network$" || echo $NOT_FOUND)
 
@@ -94,15 +100,6 @@ deploy(){
       subnet=$(docker network inspect "$network" -f '{{(index .IPAM.Config 0).Subnet}}')
     fi
 
-    if [[ "$registry" == "true" ]]
-    then
-      echo -e "${YELLOW}attaching registry to ${CYAN}$network ${NC}"
-      registry "$network"
-      registryArg="--volume \"${REGISTRY_CONFIG_PATH}:/etc/rancher/k3s/registries.yaml\""
-      echo -e "${CYAN}Injected registry configuration:${NC}"
-      cat "${REGISTRY_CONFIG_PATH}"
-    fi
-
     # Setup GitHub Actions outputs
     echo "::set-output name=network::$network"
     echo "::set-output name=subnet-CIDR::$subnet"
@@ -110,42 +107,41 @@ deploy(){
     echo -e "${YELLOW}Downloading ${CYAN}k3d@${K3D_VERSION} ${NC}see: ${K3D_URL}"
     curl --silent --fail ${K3D_URL} | TAG=${K3D_VERSION} bash
 
+    if [[ "$registry" == "true" ]]
+    then
+      echo -e "${YELLOW}Creating registry ${CYAN}k3d-${registryName}:${registryPort}${NC}"
+      init_registry "${registryPort}" "${registryName}"
+      registryArg="--registry-use=k3d-${registryName}"
+    fi
+
     echo -e "\existing_network${YELLOW}Deploy cluster ${CYAN}$name ${NC}"
     eval "k3d cluster create $name --wait $arguments --image ${K3S_VERSION} --network $network $registryArg"
 }
 
-registry(){
-    local network=$1
+init_registry(){
     # create registry if not exists
-    if [ ! "$(docker ps -q -f name=${REGISTRY_LOCAL})" ];
+    local port=$1
+    local registryName=$2
+    if [ ! "$(docker ps -q -f name=k3d-"${registryName}")" ];
     then
-      inject_configuration
-      docker volume create local_registry
-      docker container run -d --name ${REGISTRY_LOCAL} -v local_registry:/var/lib/registry --restart always -p 5000:5000 registry:2
-    fi
-    # connect registry to network if not connected yet
-    containsRegistry=$(docker network inspect "$network" | grep ${REGISTRY_LOCAL} || echo $NOT_FOUND)
-    if [[ "$containsRegistry" == "$NOT_FOUND" ]]
-    then
-      docker network connect "$network" ${REGISTRY_LOCAL}
+      k3d registry create "${registryName}" --image=docker.io/library/registry:2 --port="${port}"
     fi
 }
 
-# depending on OVERRIDE_REGISTRY_CONFIG_PATH inject given or predefined configuration
-# see: https://rancher.com/docs/k3s/latest/en/installation/private-registry/#mirrors
-inject_configuration(){
-  local registry=${OVERRIDE_REGISTRY_CONFIG_PATH:-$REGISTRY_CONFIG_PATH}
-  if [[ "$registry" == "$REGISTRY_CONFIG_PATH" ]]
-  then
-   cat > "${REGISTRY_CONFIG_PATH}" <<EOF
-mirrors:
-  "registry.localhost:5000":
-    endpoint:
-      - "http://registry.local:5000"
+test_registry(){
+  local registryPort=${REGISTRY_PORT:-$DEFAULT_REGISTRY_PORT}
+  local tag=localhost:${registryPort}/k3d-action-dummy:v0.0.1
+  echo -e "${CYAN}Test whether local registry is running${NC}"
+  echo -e "${YELLOW}push and remove image${CYAN} ${tag}${NC}"
+  docker build -t "${tag}" -f- . &> /dev/null <<EOF
+FROM scratch
+LABEL type=dummy
 EOF
-  else
-    cat "$(pwd)/${registry}" > "${REGISTRY_CONFIG_PATH}"
-  fi
+  docker push "${tag}"
+  docker image rm "${tag}" &> /dev/null
+  echo -e "${YELLOW}pull${CYAN} ${tag}${NC}"
+  docker pull "${tag}"
+  docker images
 }
 
 #######################
@@ -163,9 +159,7 @@ if [[ -z "${NO_COLOR}" ]]; then
       NC="\033[0m"
       RED="\033[0;91m"
 fi
-if [[ -z "${CLUSTER_NAME}" ]]; then
-  panic "CLUSTER_NAME must be set"
-fi
+
 
 #######################
 #
@@ -175,6 +169,9 @@ fi
 case "$1" in
     "deploy")
        deploy
+    ;;
+    "test-registry")
+       test_registry
     ;;
 #    "<put new command here>")
 #       command_handler


### PR DESCRIPTION
K3d comes with more straightforward registry usage. Thanks to that, we can simplify our action script.

 - refactor script to use k3d v4.2.0 registry (instead of injecting yaml configuration we simply use `k3d registry create.....`)
 - script for testing registries
![Screenshot 2021-02-10 at 14 13 40](https://user-images.githubusercontent.com/7195836/107514615-30aa1f80-6baa-11eb-8396-d9cc963dc57f.png)
 - Action extends properties by additional `registry-port` attribute (Optional, default 5000)
 - Custom [registry configuration](https://rancher.com/docs/k3s/latest/en/installation/private-registry/#mirrors) is not supported anymore. Removed property `override-registry-config-path`
 - FIX: `.gitignore` didn't ignore another `.gitignore` in subdirectory (in my case .idea/.gitignore)
 - **two pairs of clusters on two isolated networks with registry** split into two workflows:
 -  - two pairs of clusters on two isolated networks with one shared registry (listening on port 5000, living in one subnet)
 -  - two pairs of clusters on two isolated networks with two independent registries (listening on ports 5001, 5002, living in isolated subnets)
 - update README.md
 
closes #9 


