### PR TITLE
[Feature] Config File Support

### DIFF
--- a/.github/workflows/assets/1.yaml
+++ b/.github/workflows/assets/1.yaml
@@ -1,0 +1,27 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+servers: 1
+agents: 3
+ports:
+  - port: 0.0.0.0:80:80
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:443:443
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:5053:53/udp
+    nodeFilters:
+      - agent[0]
+options:
+  k3d:
+    wait: true
+    timeout: "60s"
+    disableLoadbalancer: true
+    disableImageVolume: true
+  k3s:
+    extraServerArgs:
+      - --no-deploy=traefik,servicelb,metrics-server
+    extraAgentArgs: []
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true

--- a/.github/workflows/assets/2.yaml
+++ b/.github/workflows/assets/2.yaml
@@ -1,0 +1,27 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+servers: 1
+agents: 3
+ports:
+  - port: 0.0.0.0:81:80
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:444:443
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:5054:53/udp
+    nodeFilters:
+      - agent[0]
+options:
+  k3d:
+    wait: true
+    timeout: "60s"
+    disableLoadbalancer: true
+    disableImageVolume: true
+  k3s:
+    extraServerArgs:
+      - --no-deploy=traefik,servicelb,metrics-server
+    extraAgentArgs: []
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true

--- a/.github/workflows/assets/3.yaml
+++ b/.github/workflows/assets/3.yaml
@@ -1,0 +1,27 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+servers: 1
+agents: 3
+ports:
+  - port: 0.0.0.0:82:80
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:445:443
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:5055:53/udp
+    nodeFilters:
+      - agent[0]
+options:
+  k3d:
+    wait: true
+    timeout: "60s"
+    disableLoadbalancer: true
+    disableImageVolume: true
+  k3s:
+    extraServerArgs:
+      - --no-deploy=traefik,servicelb,metrics-server
+    extraAgentArgs: []
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true

--- a/.github/workflows/assets/4.yaml
+++ b/.github/workflows/assets/4.yaml
@@ -1,0 +1,27 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+servers: 1
+agents: 3
+ports:
+  - port: 0.0.0.0:83:80
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:446:443
+    nodeFilters:
+      - agent[0]
+  - port: 0.0.0.0:5056:53/udp
+    nodeFilters:
+      - agent[0]
+options:
+  k3d:
+    wait: true
+    timeout: "60s"
+    disableLoadbalancer: true
+    disableImageVolume: true
+  k3s:
+    extraServerArgs:
+      - --no-deploy=traefik,servicelb,metrics-server
+    extraAgentArgs: []
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true

--- a/.github/workflows/assets/default.yaml
+++ b/.github/workflows/assets/default.yaml
@@ -1,0 +1,38 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+name: k3s-k8gb-disco2
+servers: 1
+agents: 1
+kubeAPI:
+  hostIP: "0.0.0.0"
+  hostPort: "6443"
+image: rancher/k3s:latest
+network: nw03
+labels:
+  - label: foo=bar
+    nodeFilters:
+      - loadbalancer
+ports:
+  - port: 0.0.0.0:8443:443
+    nodeFilters:
+      - loadbalancer
+  - port: 0.0.0.0:8080:80
+    nodeFilters:
+      - loadbalancer
+env:
+  - envVar: bar=baz
+    nodeFilters:
+      - all
+options:
+  k3d:
+    wait: true
+    timeout: "60s"
+    disableLoadbalancer: false
+    disableImageVolume: true
+  k3s:
+    extraServerArgs:
+      - --no-deploy=metrics-server
+    extraAgentArgs: []
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true

--- a/.github/workflows/multi-cluster-config.yaml
+++ b/.github/workflows/multi-cluster-config.yaml
@@ -1,0 +1,40 @@
+name: Multi cluster; two clusters on default network with config
+
+on:
+  [workflow_dispatch, push]
+jobs:
+  k3d-multicluster-demo:
+    name: Two clusters on default network with config
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        id: test-cluster-1
+        name: "Create 1st k3d Cluster"
+        with:
+          cluster-name: "test-cluster-1"
+          args: --config=.github/workflows/assets/1.yaml
+      - uses: ./
+        id: test-cluster-2
+        name: "Create 2nd k3d Cluster"
+        with:
+          cluster-name: "test-cluster-2"
+          args: --config=.github/workflows/assets/2.yaml
+
+      - name: Cluster info
+        run: |
+          echo test-cluster-1: ${{ steps.test-cluster-1.outputs.network }} ${{ steps.test-cluster-1.outputs.subnet-CIDR }}
+          echo test-cluster-2: ${{ steps.test-cluster-2.outputs.network }} ${{ steps.test-cluster-2.outputs.subnet-CIDR }}
+          echo
+          kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
+      - name: Nodes
+        # hack, wait until all agents are ready.
+        run: |
+          docker ps -a
+          sleep 5
+          kubectl config use-context k3d-test-cluster-1
+          kubectl get nodes -o wide
+          kubectl config use-context k3d-test-cluster-2
+          kubectl get nodes -o wide
+      - name: Network
+        run: docker network inspect k3d-action-bridge-network

--- a/.github/workflows/multi-cluster-two-piars-registry-config.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry-config.yaml
@@ -1,10 +1,10 @@
-name: Multi cluster; two pairs of clusters on two isolated networks with shared registry
+name: Multi cluster; two pairs of clusters on two isolated networks with registry from config files
 
 on:
   [workflow_dispatch, push]
 jobs:
   k3d-multicluster-demo:
-    name: Two pairs of clusters on two isolated networks with shared registry
+    name: Two pairs of clusters on two isolated networks with registry from config files
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -16,10 +16,10 @@ jobs:
           network: "nw01"
           subnet-CIDR: "172.20.0.0/24"
           use-default-registry: true
+          registry-port: 5001
           args: >-
             --agents 1
-            --no-lb
-            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+            --config=.github/workflows/assets/1.yaml
 
       - uses: ./
         id: test-cluster-1-b
@@ -27,10 +27,11 @@ jobs:
         with:
           cluster-name: "test-cluster-2-a"
           network: "nw01"
+          use-default-registry: true
+          registry-port: 5001
           args: >-
             --agents 1
-            --no-lb
-            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+            --config=.github/workflows/assets/2.yaml
 
       - uses: ./
         id: test-cluster-2-a
@@ -39,10 +40,11 @@ jobs:
           cluster-name: "test-cluster-1-b"
           network: "nw02"
           subnet-CIDR: "172.20.1.0/24"
+          use-default-registry: true
+          registry-port: 5001
           args: >-
             --agents 1
-            --no-lb
-            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+            --config=.github/workflows/assets/3.yaml
 
       - uses: ./
         id: test-cluster-2-b
@@ -50,10 +52,11 @@ jobs:
         with:
           cluster-name: "test-cluster-2-b"
           network: "nw02"
+          use-default-registry: true
+          registry-port: 5001
           args: >-
             --agents 1
-            --no-lb
-            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+            --config=.github/workflows/assets/4.yaml
 
       - name: Cluster info
         run: |
@@ -88,7 +91,8 @@ jobs:
           docker network inspect nw01
           docker network inspect nw02
 
-      - name: Test registry
+      - name: Test registry nw01
         env:
-          REGISTRY_PORT: 5000
+          REGISTRY_PORT: 5001
         run: ./run.sh test-registry
+

--- a/.github/workflows/multi-cluster-two-piars-registry.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry.yaml
@@ -43,7 +43,7 @@ jobs:
           network: "nw02"
           subnet-CIDR: "172.20.1.0/24"
           use-default-registry: true
-          registry-port: 5002
+          registry-port: 5001
           args: >-
             --agents 1
             --no-lb
@@ -56,7 +56,7 @@ jobs:
           cluster-name: "test-cluster-2-b"
           network: "nw02"
           use-default-registry: true
-          registry-port: 5002
+          registry-port: 5001
           args: >-
             --agents 1
             --no-lb
@@ -100,7 +100,3 @@ jobs:
           REGISTRY_PORT: 5001
         run: ./run.sh test-registry
 
-      - name: Test registry nw02
-        env:
-          REGISTRY_PORT: 5002
-        run: ./run.sh test-registry

--- a/.github/workflows/single-cluster-config.yaml
+++ b/.github/workflows/single-cluster-config.yaml
@@ -1,0 +1,32 @@
+name: Single cluster on default network with config
+
+on:
+  [workflow_dispatch, push]
+jobs:
+  k3d-single-cluster-demo:
+    name: Single cluster on default network with config
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        id: single-cluster
+        name: "Create single k3d Cluster"
+        with:
+          cluster-name: "test-cluster-1"
+          args: >-
+            --agents 1
+            --config=.github/workflows/assets/1.yaml
+      - name: Cluster info
+        run: |
+          echo ${{ steps.single-cluster.outputs.network }} ${{ steps.single-cluster.outputs.subnet-CIDR }}
+          echo
+          kubectl cluster-info --context k3d-test-cluster-1
+      - name: Nodes
+        # hack, wait until agents are ready...
+        run: |
+          docker ps -a
+          sleep 10
+          kubectl config use-context k3d-test-cluster-1
+          kubectl get nodes -o wide
+      - name: Network
+        run: docker network inspect k3d-action-bridge-network


### PR DESCRIPTION
Closes #8

 - configuration examples
   - Single cluster on default network with config
   - Multi cluster; two clusters on default network with config
   - Multi cluster; two pairs of clusters on two isolated networks with registry from config files

 - Update README.md
 - Tested
   - against k8gb
   - within action
   - registry tested from inside, outside cluster
   - add new config test files

 - Registry
   - partially revert, it creates direct registry on k3s
