### PR TITLE
Wait until agents are ready

### DIFF
--- a/.github/workflows/multi-cluster-config.yaml
+++ b/.github/workflows/multi-cluster-config.yaml
@@ -28,10 +28,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-2

--- a/.github/workflows/multi-cluster-on-isolated-networks.yaml
+++ b/.github/workflows/multi-cluster-on-isolated-networks.yaml
@@ -45,10 +45,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-2

--- a/.github/workflows/multi-cluster-registry.yaml
+++ b/.github/workflows/multi-cluster-registry.yaml
@@ -36,10 +36,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-2

--- a/.github/workflows/multi-cluster-two-piars-registry-config.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry-config.yaml
@@ -72,10 +72,8 @@ jobs:
           kubectl cluster-info --context k3d-test-cluster-2-b
 
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1-a
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-1-b

--- a/.github/workflows/multi-cluster-two-piars-registry-shared.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry-shared.yaml
@@ -69,10 +69,8 @@ jobs:
           kubectl cluster-info --context k3d-test-cluster-2-b
 
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1-a
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-1-b

--- a/.github/workflows/multi-cluster-two-piars-registry.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry.yaml
@@ -76,10 +76,8 @@ jobs:
           kubectl cluster-info --context k3d-test-cluster-2-b
 
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1-a
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-1-b

--- a/.github/workflows/multi-cluster-two-piars.yaml
+++ b/.github/workflows/multi-cluster-two-piars.yaml
@@ -68,10 +68,8 @@ jobs:
           kubectl cluster-info --context k3d-test-cluster-2-b
 
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1-a
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-1-b

--- a/.github/workflows/multi-cluster.yaml
+++ b/.github/workflows/multi-cluster.yaml
@@ -40,10 +40,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
-        # hack, wait until all agents are ready.
         run: |
           docker ps -a
-          sleep 5
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
           kubectl config use-context k3d-test-cluster-2

--- a/.github/workflows/single-cluster-config.yaml
+++ b/.github/workflows/single-cluster-config.yaml
@@ -22,10 +22,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1
       - name: Nodes
-        # hack, wait until agents are ready...
         run: |
           docker ps -a
-          sleep 10
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
       - name: Network

--- a/.github/workflows/single-cluster-registry.yaml
+++ b/.github/workflows/single-cluster-registry.yaml
@@ -25,10 +25,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1
       - name: Nodes
-        # hack, wait until agents are ready...
         run: |
           docker ps -a
-          sleep 10
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
       - name: Network

--- a/.github/workflows/single-cluster.yaml
+++ b/.github/workflows/single-cluster.yaml
@@ -26,10 +26,8 @@ jobs:
           echo
           kubectl cluster-info --context k3d-test-cluster-1
       - name: Nodes
-        # hack, wait until agents are ready...
         run: |
           docker ps -a
-          sleep 10
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
       - name: Network


### PR DESCRIPTION
K3d waits for k3s to report, but kubelets starts a second later.
I implemented function wait_for_nodes(), waiting until all agents are ready.
Changes:
 - wait_for_nodes implemented
 - remove sleep hack from tests

closes #14