### PR TITLE
[Fix] No resource found

### DIFF
--- a/.github/workflows/single-cluster-node-list.yaml
+++ b/.github/workflows/single-cluster-node-list.yaml
@@ -1,0 +1,18 @@
+name: Retrieving nodes right after we create cluster
+
+on:
+  [workflow_dispatch, push]
+jobs:
+  k3d-node-list-demo:
+    name: Retrieving nodes right after we create cluster
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        name: node-list
+        with:
+          cluster-name: "node-list"
+          args: >-
+            --no-lb
+            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+      - run: kubectl get nodes

--- a/run.sh
+++ b/run.sh
@@ -183,13 +183,12 @@ wait_for_nodes(){
     # shellcheck disable=SC2162
     while read status
     do
-      if [[ "$status" == "NotReady" ]]
+      if [ "$status" == "NotReady" ] || [ "$status" == "" ]
       then
         readyNodes=0
         break
       fi
     done <<< "$(echo -e  "$statusList")"
-
     # all nodes are ready; exit
     if [[ $readyNodes == 1 ]]
     then


### PR DESCRIPTION
kubectl returns message `No resources found` before nodes start initialize.
Change in action handles such case.

 - update `wait_for_nodes`
 - add workflow, reading nodes immediately after `k3d create cluster`

closes #14 