### PR TITLE
k3d-action user specifies k3s version explicitly

### DIFF
--- a/.github/workflows/assets/1.yaml
+++ b/.github/workflows/assets/1.yaml
@@ -1,5 +1,6 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
+image: docker.io/rancher/k3s:v1.20.4-k3s1
 servers: 1
 agents: 3
 ports:

--- a/.github/workflows/assets/2.yaml
+++ b/.github/workflows/assets/2.yaml
@@ -1,5 +1,6 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
+image: docker.io/rancher/k3s:v1.20.5-k3s1
 servers: 1
 agents: 3
 ports:

--- a/.github/workflows/assets/3.yaml
+++ b/.github/workflows/assets/3.yaml
@@ -1,5 +1,6 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
+image: docker.io/rancher/k3s:v1.20.5-k3s1
 servers: 1
 agents: 3
 ports:

--- a/.github/workflows/assets/4.yaml
+++ b/.github/workflows/assets/4.yaml
@@ -1,5 +1,6 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
+# image: default k3s version
 servers: 1
 agents: 3
 ports:

--- a/.github/workflows/multi-cluster-config.yaml
+++ b/.github/workflows/multi-cluster-config.yaml
@@ -19,7 +19,7 @@ jobs:
         name: "Create 2nd k3d Cluster"
         with:
           cluster-name: "test-cluster-2"
-          args: --config=.github/workflows/assets/2.yaml
+          args: --config=.github/workflows/assets/2.yaml # test: k3s version is different from 1.yaml
 
       - name: Cluster info
         run: |

--- a/.github/workflows/multi-cluster-two-piars-registry.yaml
+++ b/.github/workflows/multi-cluster-two-piars-registry.yaml
@@ -20,6 +20,7 @@ jobs:
           args: >-
             --agents 1
             --no-lb
+            --image docker.io/rancher/k3s:v1.20.4-k3s1
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
       - uses: ./
@@ -33,6 +34,7 @@ jobs:
           args: >-
             --agents 1
             --no-lb
+            --image docker.io/rancher/k3s:v1.20.4-k3s1
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
       - uses: ./
@@ -47,6 +49,7 @@ jobs:
           args: >-
             --agents 1
             --no-lb
+            --image docker.io/rancher/k3s:v1.20.4-k3s1
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
       - uses: ./
@@ -60,6 +63,7 @@ jobs:
           args: >-
             --agents 1
             --no-lb
+            --image docker.io/rancher/k3s:v1.20.4-k3s1
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
       - name: Cluster info

--- a/README.md
+++ b/README.md
@@ -59,20 +59,27 @@ For more details see: [Multi Cluster on isolated networks](#multi-cluster-on-iso
 
 ### Version mapping
 Implementation of additional features brings complexity and sometimes may happen that extra feature is broken in special cases. 
-To prevent potential issues due to usage such versions, the k3d, k3s versions are hard-coded.
+To prevent potential issues due to usage such versions, the k3d version is predefined.
 
 | k3d-action |   k3d   |           k3s           |
 |:----------:|:-------:|:-----------------------:|
 | v1.1.0     |  [v3.4.0](https://github.com/rancher/k3d/releases/tag/v3.4.0) | [rancher/k3s:v1.20.2-k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.20.2%2Bk3s1)|
 | v1.2.0     |  [v4.2.0](https://github.com/rancher/k3d/releases/tag/v4.2.0) | [rancher/k3s:v1.20.2-k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.20.2%2Bk3s1)|
 | v1.3.0     |  [v4.2.0](https://github.com/rancher/k3d/releases/tag/v4.2.0) | [rancher/k3s:v1.20.4-k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.20.4%2Bk3s1)|
+| v1.4.0     |  [v4.4.1](https://github.com/rancher/k3d/releases/tag/v4.4.1) | specified by k3d or [set image explicitly](https://hub.docker.com/r/rancher/k3s/tags?page=1&ordering=last_updated)|
 
+From `v1.4.0` would k3d-action users set k3s version explicitly via [configuration](#config-file-support) or 
+argument e.g.`--image docker.io/rancher/k3s:v1.20.4-k3s1` otherwise k3d specifies which version will be used. 
+
+For further k3s details see: 
+ - docker [rancher/k3s](https://hub.docker.com/r/rancher/k3s/tags?page=2&ordering=last_updated)
+ - github [k3s/releases](https://github.com/k3s-io/k3s/releases)
 
 ## Single Cluster
 Although AbsaOSS/k3d-action strongly supports multi-cluster. Single cluster scenarios are very popular. The minimum single-cluster 
 configuration looks like this :
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create Single Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -82,7 +89,7 @@ k3d creates a cluster with one worker node (with [traefik](https://traefik.io/) 
 default load-balancer node. In real scenarios you might prefer to do some port mapping and disable default load balancer. 
 Such an action would look like this:
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create Single Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -92,6 +99,7 @@ Such an action would look like this:
             -p "5053:53/udp@agent[0]"
             --agents 3
             --no-lb
+            --image docker.io/rancher/k3s:v1.20.4-k3s1
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 ```
 The created cluster exposes two TCP (`:8083`,`:8443`) and one UDP (`:5053`) ports. The cluster comprises one server, three 
@@ -120,6 +128,7 @@ configured.
 ```yaml
 apiVersion: k3d.io/v1alpha2
 kind: Simple
+image: docker.io/rancher/k3s:v1.20.5-k3s1
 servers: 1
 agents: 3 # The action will overwrite this by 1
 ports:
@@ -157,7 +166,7 @@ manually.
 ### Multi Cluster on default network
 ```yaml
       - uses: actions/checkout@v2
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 1st Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -168,7 +177,7 @@ manually.
             --agents 3
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 2nd Cluster"
         with:
           cluster-name: "test-cluster-2"
@@ -181,7 +190,7 @@ manually.
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 ```
 Both clusters comprise one server node and three agents nodes. Because of port collision, each cluster must expose 
-different ports.
+different ports. Because k3s version is not specified, the clusters will run against latest k3s.
 
 For more details see: 
  - multi-cluster [Demo](https://github.com/AbsaOSS/k3d-action/actions?query=workflow%3A%22Multi+cluster%3B+two+clusters+on+default+network%22), 
@@ -191,7 +200,7 @@ For more details see:
    
 ### Multi Cluster on isolated networks
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 1st Cluster in 172.20.0.0/24"
         id: test-cluster-1
         with:
@@ -206,7 +215,7 @@ For more details see:
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 2nd Cluster in 172.20.1.0/24"
         id: test-cluster-2
         with:
@@ -239,7 +248,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
 [Source](./.github/workflows/multi-cluster-on-isolated-networks.yaml)
 ### Two pairs of clusters on two isolated networks
 ```yaml
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 1st Cluster in 172.20.0.0/24"
         with:
           cluster-name: "test-cluster-1-a"
@@ -250,7 +259,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 2nd Cluster in 172.20.0.0/24"
         with:
           cluster-name: "test-cluster-2-a"
@@ -260,7 +269,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 1st Cluster in 172.20.1.0/24"
         with:
           cluster-name: "test-cluster-1-b"
@@ -271,7 +280,7 @@ For more details see: [Demo](https://github.com/AbsaOSS/k3d-action/actions?query
             --no-lb
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
 
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         name: "Create 2nd Cluster in 172.20.1.0/24"
         with:
           cluster-name: "test-cluster-2-b"
@@ -300,7 +309,7 @@ Example below demonstrates how to interact with imported docker registry:
 ```yaml
     steps:
       - uses: actions/checkout@v2
-      - uses: AbsaOSS/k3d-action@v1.3.1
+      - uses: AbsaOSS/k3d-action@v1.4.0
         id: single-cluster
         name: "Create single k3d Cluster with imported Registry"
         with:

--- a/run.sh
+++ b/run.sh
@@ -25,8 +25,7 @@ CYAN=
 RED=
 NC=
 K3D_URL=https://raw.githubusercontent.com/rancher/k3d/main/install.sh
-K3D_VERSION=v4.2.0
-K3S_VERSION=docker.io/rancher/k3s:v1.20.4-k3s1
+K3D_VERSION=v4.4.1
 DEFAULT_NETWORK=k3d-action-bridge-network
 DEFAULT_SUBNET=172.16.0.0/24
 NOT_FOUND=k3d-not-found-network
@@ -131,7 +130,7 @@ deploy(){
     curl --silent --fail ${K3D_URL} | TAG=${K3D_VERSION} bash
 
     echo -e "\existing_network${YELLOW}Deploy cluster ${CYAN}$name ${NC}"
-    eval "k3d cluster create $name --wait $arguments --image ${K3S_VERSION} --network $network $registryArg"
+    eval "k3d cluster create $name --wait $arguments --network $network $registryArg"
     wait_for_nodes
 }
 


### PR DESCRIPTION
Related to #19

There is an increased demand for k3d-action to have a configurable k3s version.
Following implementation keeps responsibility for k3s version on users.
If user doesn't specify k3s version via configuration or action argument, the k3d will choose version.

PR affects:
 - implementation
 - tests
 - README.md

I'm expecting to release k3d-action@v1.4.0, that's why I replaced examples in README.md to use AbsaOSS/k3d-action@v1.4.0 instead of AbsaOSS/k3d-action@v1.3.1