### PR TITLE
Removing network configuration

### DIFF
--- a/.github/workflows/assets/1.yaml
+++ b/.github/workflows/assets/1.yaml
@@ -3,6 +3,7 @@ kind: Simple
 image: docker.io/rancher/k3s:v1.21.2-k3s1
 servers: 1
 agents: 3
+network: nw01
 ports:
   - port: 0.0.0.0:80:80
     nodeFilters:

--- a/.github/workflows/assets/2.yaml
+++ b/.github/workflows/assets/2.yaml
@@ -3,6 +3,7 @@ kind: Simple
 image: docker.io/rancher/k3s:v1.21.2-k3s1
 servers: 1
 agents: 3
+network: nw01
 ports:
   - port: 0.0.0.0:81:80
     nodeFilters:

--- a/.github/workflows/assets/3.yaml
+++ b/.github/workflows/assets/3.yaml
@@ -3,6 +3,7 @@ kind: Simple
 image: docker.io/rancher/k3s:v1.21.2-k3s1
 servers: 1
 agents: 3
+network: nw02
 ports:
   - port: 0.0.0.0:82:80
     nodeFilters:

--- a/.github/workflows/assets/4.yaml
+++ b/.github/workflows/assets/4.yaml
@@ -3,6 +3,7 @@ kind: Simple
 # image: default k3s version
 servers: 1
 agents: 3
+network: nw02
 ports:
   - port: 0.0.0.0:83:80
     nodeFilters:

--- a/.github/workflows/multi-cluster-config.yaml
+++ b/.github/workflows/multi-cluster-config.yaml
@@ -1,31 +1,26 @@
-name: Multi cluster; two clusters on default network with config
+name: Two clusters on default networks with config
 
 on:
   [workflow_dispatch, push]
 jobs:
   k3d-multicluster-demo:
-    name: Two clusters on default network with config
+    name: Two clusters on default networks with config
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: test-cluster-1
         name: "Create 1st k3d Cluster"
         with:
           cluster-name: "test-cluster-1"
           args: --config=.github/workflows/assets/1.yaml
       - uses: ./
-        id: test-cluster-2
         name: "Create 2nd k3d Cluster"
         with:
           cluster-name: "test-cluster-2"
-          args: --config=.github/workflows/assets/2.yaml # test: k3s version is different from 1.yaml
+          args: --config=.github/workflows/assets/3.yaml # test: k3s version is different from 1.yaml
 
       - name: Cluster info
         run: |
-          echo test-cluster-1: ${{ steps.test-cluster-1.outputs.network }} ${{ steps.test-cluster-1.outputs.subnet-CIDR }}
-          echo test-cluster-2: ${{ steps.test-cluster-2.outputs.network }} ${{ steps.test-cluster-2.outputs.subnet-CIDR }}
-          echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
         run: |
@@ -35,4 +30,7 @@ jobs:
           kubectl config use-context k3d-test-cluster-2
           kubectl get nodes -o wide
       - name: Network
-        run: docker network inspect k3d-action-bridge-network
+        run: |
+          docker network inspect nw01
+          docker network inspect nw02
+

--- a/.github/workflows/multi-cluster-on-isolated-networks.yaml
+++ b/.github/workflows/multi-cluster-on-isolated-networks.yaml
@@ -1,4 +1,4 @@
-name: Multi cluster; two clusters on two isolated networks
+name: Two clusters on two isolated networks
 
 on:
   [workflow_dispatch, push]
@@ -9,12 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: test-cluster-1
-        name: "Create 1st k3d Cluster in 172.20.0.0/24"
+        name: "Create 1st k3d Cluster in 172.18.0.0/16"
         with:
           cluster-name: "test-cluster-1"
-          network: "nw01"
-          subnet-CIDR: "172.20.0.0/24"
           args: >-
             -p "80:80@agent:0:direct"
             -p "443:443@agent:0:direct"
@@ -22,14 +19,11 @@ jobs:
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-
+            --network nw01
       - uses: ./
-        id: test-cluster-2
-        name: "Create 1nd k3d Cluster in 172.20.1.0/24"
+        name: "Create 1nd k3d Cluster in 172.19.0.0/16"
         with:
           cluster-name: "test-cluster-2"
-          network: "nw02"
-          subnet-CIDR: "172.20.1.0/24"
           args: >-
             -p "81:80@agent:0:direct"
             -p "444:443@agent:0:direct"
@@ -37,12 +31,9 @@ jobs:
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-
+            --network nw02
       - name: Cluster info
         run: |
-          echo test-cluster-1: ${{ steps.test-cluster-1.outputs.network }} ${{ steps.test-cluster-1.outputs.subnet-CIDR }}
-          echo test-cluster-2: ${{ steps.test-cluster-2.outputs.network }} ${{ steps.test-cluster-2.outputs.subnet-CIDR }}
-          echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
         run: |

--- a/.github/workflows/multi-cluster-two-piars.yaml
+++ b/.github/workflows/multi-cluster-two-piars.yaml
@@ -9,74 +9,74 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: test-cluster-1-a
-        name: "Create 1st k3d Cluster in 172.20.0.0/24"
+        name: "Create 1st Cluster in 172.18.0.0/16"
         with:
-          cluster-name: "test-cluster-1-a"
-          network: "nw01"
-          subnet-CIDR: "172.20.0.0/24"
+          cluster-name: "test-cluster-1"
           args: >-
+            -p "80:80@agent:0:direct"
+            -p "443:443@agent:0:direct"
+            -p "5053:53/udp@agent:0:direct"
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --network "nw01"
 
       - uses: ./
-        id: test-cluster-1-b
-        name: "Create 2nd k3d Cluster in 172.20.0.0/24"
+        name: "Create 2nd Cluster in 172.18.0.0/16"
         with:
-          cluster-name: "test-cluster-2-a"
-          network: "nw01"
+          cluster-name: "test-cluster-2"
           args: >-
+            -p "81:80@agent:0:direct"
+            -p "444:443@agent:0:direct"
+            -p "5054:53/udp@agent:0:direct"
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --network "nw01"
 
       - uses: ./
-        id: test-cluster-2-a
-        name: "Create 1st k3d Cluster in 172.20.1.0/24"
+        name: "Create 1st Cluster in 172.19.0.0/16"
         with:
-          cluster-name: "test-cluster-1-b"
-          network: "nw02"
-          subnet-CIDR: "172.20.1.0/24"
+          cluster-name: "test-cluster-3"
           args: >-
+            -p "82:80@agent:0:direct"
+            -p "445:443@agent:0:direct"
+            -p "5055:53/udp@agent:0:direct"
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --network "nw02"
 
       - uses: ./
-        id: test-cluster-2-b
-        name: "Create 2nd k3d Cluster in 172.20.1.0/24"
+        name: "Create 2nd Cluster in 172.19.0.0/16"
         with:
-          cluster-name: "test-cluster-2-b"
-          network: "nw02"
+          cluster-name: "test-cluster-4"
           args: >-
+            -p "83:80@agent:0:direct"
+            -p "446:443@agent:0:direct"
+            -p "5056:53/udp@agent:0:direct"
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+            --network "nw02"
 
       - name: Cluster info
         run: |
-          echo
-          echo test-cluster-1-a: ${{ steps.test-cluster-1-a.outputs.network }} ${{ steps.test-cluster-1-a.outputs.subnet-CIDR }}
-          echo test-cluster-1-b: ${{ steps.test-cluster-1-b.outputs.network }} ${{ steps.test-cluster-1-b.outputs.subnet-CIDR }}
-          echo test-cluster-2-a: ${{ steps.test-cluster-2-a.outputs.network }} ${{ steps.test-cluster-2-a.outputs.subnet-CIDR }}
-          echo test-cluster-2-b: ${{ steps.test-cluster-2-b.outputs.network }} ${{ steps.test-cluster-2-b.outputs.subnet-CIDR }}
-          echo
-          kubectl cluster-info --context k3d-test-cluster-1-a
-          kubectl cluster-info --context k3d-test-cluster-2-a
-          kubectl cluster-info --context k3d-test-cluster-1-b
-          kubectl cluster-info --context k3d-test-cluster-2-b
+          kubectl cluster-info --context k3d-test-cluster-1
+          kubectl cluster-info --context k3d-test-cluster-2
+          kubectl cluster-info --context k3d-test-cluster-3
+          kubectl cluster-info --context k3d-test-cluster-4
 
       - name: Nodes
         run: |
           docker ps -a
-          kubectl config use-context k3d-test-cluster-1-a
+          kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
-          kubectl config use-context k3d-test-cluster-1-b
+          kubectl config use-context k3d-test-cluster-2
           kubectl get nodes -o wide
-          kubectl config use-context k3d-test-cluster-2-a
+          kubectl config use-context k3d-test-cluster-3
           kubectl get nodes -o wide
-          kubectl config use-context k3d-test-cluster-2-b
+          kubectl config use-context k3d-test-cluster-4
           kubectl get nodes -o wide
 
       - name: Network

--- a/.github/workflows/multi-cluster.yaml
+++ b/.github/workflows/multi-cluster.yaml
@@ -1,15 +1,14 @@
-name: Multi cluster; two clusters on default network
+name: Two clusters on default networks
 
 on:
   [workflow_dispatch, push]
 jobs:
   k3d-multicluster-demo:
-    name: Two clusters on default network
+    name: Two clusters on default networks
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: test-cluster-1
         name: "Create 1st k3d Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -21,7 +20,6 @@ jobs:
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - uses: ./
-        id: test-cluster-2
         name: "Create 2nd k3d Cluster"
         with:
           cluster-name: "test-cluster-2"
@@ -32,12 +30,8 @@ jobs:
             --agents 3
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-
       - name: Cluster info
         run: |
-          echo test-cluster-1: ${{ steps.test-cluster-1.outputs.network }} ${{ steps.test-cluster-1.outputs.subnet-CIDR }}
-          echo test-cluster-2: ${{ steps.test-cluster-2.outputs.network }} ${{ steps.test-cluster-2.outputs.subnet-CIDR }}
-          echo
           kubectl cluster-info --context k3d-test-cluster-1 && kubectl cluster-info --context k3d-test-cluster-2
       - name: Nodes
         run: |
@@ -47,4 +41,6 @@ jobs:
           kubectl config use-context k3d-test-cluster-2
           kubectl get nodes -o wide
       - name: Network
-        run: docker network inspect k3d-action-bridge-network
+        run: |
+          docker network inspect k3d-test-cluster-1
+          docker network inspect k3d-test-cluster-2

--- a/.github/workflows/single-cluster-config.yaml
+++ b/.github/workflows/single-cluster-config.yaml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: single-cluster
         name: "Create single k3d Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -18,8 +17,6 @@ jobs:
             --config=.github/workflows/assets/1.yaml
       - name: Cluster info
         run: |
-          echo ${{ steps.single-cluster.outputs.network }} ${{ steps.single-cluster.outputs.subnet-CIDR }}
-          echo
           kubectl cluster-info --context k3d-test-cluster-1
       - name: Nodes
         run: |
@@ -27,4 +24,4 @@ jobs:
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
       - name: Network
-        run: docker network inspect k3d-action-bridge-network
+        run: docker network inspect nw01

--- a/.github/workflows/single-cluster-import-registry.yaml
+++ b/.github/workflows/single-cluster-import-registry.yaml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: single-cluster
         name: "Create single k3d Cluster with imported Registry"
         with:
           cluster-name: test-cluster-1
@@ -24,8 +23,6 @@ jobs:
           kubectl apply -f .github/workflows/assets/pod.yaml
       - name: Cluster info
         run: |
-          echo ${{ steps.single-cluster.outputs.network }} ${{ steps.single-cluster.outputs.subnet-CIDR }}
-          echo
           kubectl cluster-info --context k3d-test-cluster-1
       - name: Nodes
         run: |
@@ -33,4 +30,4 @@ jobs:
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
       - name: Network
-        run: docker network inspect k3d-action-bridge-network
+        run: docker network inspect k3d-test-cluster-1

--- a/.github/workflows/single-cluster.yaml
+++ b/.github/workflows/single-cluster.yaml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        id: single-cluster
         name: "Create single k3d Cluster"
         with:
           cluster-name: "test-cluster-1"
@@ -22,8 +21,6 @@ jobs:
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
       - name: Cluster info
         run: |
-          echo ${{ steps.single-cluster.outputs.network }} ${{ steps.single-cluster.outputs.subnet-CIDR }}
-          echo
           kubectl cluster-info --context k3d-test-cluster-1
       - name: Nodes
         run: |
@@ -31,4 +28,4 @@ jobs:
           kubectl config use-context k3d-test-cluster-1
           kubectl get nodes -o wide
       - name: Network
-        run: docker network inspect k3d-action-bridge-network
+        run: docker network inspect k3d-test-cluster-1

--- a/action.yaml
+++ b/action.yaml
@@ -27,19 +27,6 @@ inputs:
   args:
     description: "(Optional) Additional arguments to k3d cluster. see: https://k3d.io/usage/commands/"
     required: false
-  network:
-    description: "(Optional) Cluster network. Default value k3d-action-bridge-network"
-    required: false
-  subnet-CIDR:
-    description: "(Optional) Cluster subnet CIDR. Default value 172.16.0.0/24 in case network is not set."
-    required: false
-outputs:
-  network:
-    description: "Detected k3d version"
-    value: ${{ steps.main.outputs.network }}
-  subnet-CIDR:
-    description: "Detected k3d network subnet"
-    value: ${{ steps.main.outputs.subnet-CIDR }}
 runs:
   using: composite
   steps:
@@ -49,6 +36,3 @@ runs:
       env:
         CLUSTER_NAME: ${{ inputs.cluster-name }}
         ARGS: ${{ inputs.args }}
-        NETWORK: ${{ inputs.network }}
-        SUBNET_CIDR: ${{ inputs.subnet-CIDR }}
-

--- a/run.sh
+++ b/run.sh
@@ -26,10 +26,6 @@ RED=
 NC=
 K3D_URL=https://raw.githubusercontent.com/rancher/k3d/main/install.sh
 K3D_VERSION=v5.1.0
-DEFAULT_NETWORK=k3d-action-bridge-network
-DEFAULT_SUBNET=172.16.0.0/24
-NOT_FOUND=k3d-not-found-network
-DEFAULT_REGISTRY_PORT=5000
 
 #######################
 #
@@ -48,12 +44,6 @@ usage(){
                         CLUSTER_NAME (Required) k3d cluster name.
 
                         ARGS (Optional) k3d arguments.
-
-                        NETWORK (Optional) If not set than default k3d-action-bridge-network is created
-                                               and all clusters share that network.
-
-                        SUBNET_CIDR (Optional) If not set than default 172.16.0.0/24 is used. Variable requires
-                                              NETWORK to be set.
 EOF
 }
 
@@ -66,52 +56,16 @@ panic() {
 deploy(){
     local name=${CLUSTER_NAME}
     local arguments=${ARGS:-}
-    local network=${NETWORK:-$DEFAULT_NETWORK}
-    local subnet=${SUBNET_CIDR:-$DEFAULT_SUBNET}
-    local registry=${USE_DEFAULT_REGISTRY:-}
-    local registryPort=${REGISTRY_PORT:-$DEFAULT_REGISTRY_PORT}
-    local registryArg
 
     if [[ -z "${CLUSTER_NAME}" ]]; then
       panic "CLUSTER_NAME must be set"
     fi
 
-    existing_network=$(docker network list | awk '   {print $2 }' | grep -w "^$network$" || echo $NOT_FOUND)
-
-    if [[ ($network == "$DEFAULT_NETWORK") && ($subnet != "$DEFAULT_SUBNET") ]]
-    then
-      panic "You can't specify custom subnet for default network."
-    fi
-
-    if [[ ($network != "$DEFAULT_NETWORK") && ($subnet == "$DEFAULT_SUBNET") ]]
-    then
-      if [[ "$existing_network" == "$NOT_FOUND" ]]
-      then
-        panic "Subnet CIDR must be specified for custom network"
-      fi
-    fi
-
-    echo
-
-    # create network if doesn't exists
-    if [[ "$existing_network" == "$NOT_FOUND" ]]
-    then
-      echo -e "${YELLOW}create new network ${CYAN}$network $subnet ${NC}"
-      docker network create --driver=bridge --subnet="$subnet" "$network"
-    else
-      echo -e "${YELLOW}attaching nodes to existing ${CYAN}$network ${NC}"
-      subnet=$(docker network inspect "$network" -f '{{(index .IPAM.Config 0).Subnet}}')
-    fi
-
-    # Setup GitHub Actions outputs
-    echo "::set-output name=network::$network"
-    echo "::set-output name=subnet-CIDR::$subnet"
-
     echo -e "${YELLOW}Downloading ${CYAN}k3d@${K3D_VERSION} ${NC}see: ${K3D_URL}"
     curl --silent --fail ${K3D_URL} | TAG=${K3D_VERSION} bash
 
     echo -e "\existing_network${YELLOW}Deploy cluster ${CYAN}$name ${NC}"
-    eval "k3d cluster create $name --wait $arguments --network $network $registryArg"
+    eval "k3d cluster create $name --wait $arguments"
     wait_for_nodes
 }
 


### PR DESCRIPTION
Advanced networking is not used anymore as k3d provides native way how to work with networks.
With latest k3d, the network can be specified in the configuration or via argument.
Subnet unfortunately not and I couldn't even use subnet as a separate argument.
I think it would be best to make a PR to k3d to define the subnet in the configuration.

I decided to delete the networking configurations.

Signed-off-by: kuritka <kuritka@gmail.com>