### PR TITLE
k3d-version parameter allowing to specify concrete k3d version

### DIFF
--- a/.github/workflows/single-cluster-specified-k3d-version.yaml
+++ b/.github/workflows/single-cluster-specified-k3d-version.yaml
@@ -1,4 +1,4 @@
-name: Retrieving nodes right after we create cluster
+name: Use specified k3d version
 
 on:
   [workflow_dispatch, push]

--- a/.github/workflows/single-cluster-specified-k3d-version.yaml
+++ b/.github/workflows/single-cluster-specified-k3d-version.yaml
@@ -1,0 +1,19 @@
+name: Retrieving nodes right after we create cluster
+
+on:
+  [workflow_dispatch, push]
+jobs:
+  k3d-specified-k3d-version-demo:
+    name: Use specified k3d version
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        name: k3d-version-specified
+        with:
+          cluster-name: "k3d-version-specified"
+          k3d-version: v5.0.3
+          args: >-
+            --no-lb
+            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+      - run: k3d version | grep v5.0.3

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ AbsaOSS/k3d-action defines several input attributes and two outputs:
 
 - `args` (Optional) list of k3d arguments defined by [k3d command tree](https://k3d.io/usage/commands/)
 
+- `k3d-version` (Optional) version of k3d. If not set, will be used version from mapping below.
+
 ### Version mapping
 
 Implementation of additional features brings complexity and sometimes it may happen that extra feature is broken in special cases.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ AbsaOSS/k3d-action defines several input attributes and two outputs:
 ### Version mapping
 
 Implementation of additional features brings complexity and sometimes it may happen that extra feature is broken in special cases.
-Because of that, `k3d-action` has fixed default, tested against compatibility `k3d` version.
+To prevent potential issues, the `k3d` version is fixed according to the mapping below:
 
 | k3d-action |   k3d   |           k3s           |
 |:----------:|:-------:|:-----------------------:|

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ AbsaOSS/k3d-action defines several input attributes and two outputs:
 
 Implementation of additional features brings complexity and sometimes it may happen that extra feature is broken in special cases.
 Because of that, `k3d-action` has fixed default, tested against compatibility `k3d` version.
-Starting from k3d-action v2.1.0 users can explicitly set k3d version via `k3d-version` input e.g. `k3d-version: v5.2.2` otherwise k3d uses default version according to the mapping above.
 
 | k3d-action |   k3d   |           k3s           |
 |:----------:|:-------:|:-----------------------:|
@@ -57,8 +56,9 @@ Starting from k3d-action v2.1.0 users can explicitly set k3d version via `k3d-ve
 | v1.5.0     |  [v4.4.7](https://github.com/rancher/k3d/releases/tag/v4.4.7) | [rancher/k3s:v1.21.2-k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.21.2%2Bk3s1) or [set image explicitly](https://hub.docker.com/r/rancher/k3s/tags?page=1&ordering=last_updated)|
 | v2.0.0     |  [v5.1.0](https://github.com/rancher/k3d/releases/tag/v5.1.0) | [rancher/k3s:v1.22.3+k3s1](https://github.com/k3s-io/k3s/releases/tag/v1.22.3%2Bk3s1) or [set image explicitly](https://hub.docker.com/r/rancher/k3s/tags?page=1&ordering=last_updated)|
 
-Starting from `k3d-action` `v1.4.0` users can explicitly set [`k3s` image version](https://hub.docker.com/r/rancher/k3s/tags?page=1&ordering=last_updated) via [configuration](#config-file-support) or
-argument e.g.`--image docker.io/rancher/k3s:v1.20.4-k3s1` otherwise k3d uses default version accordng to the mapping above.
+Starting from `k3d-action` `v2.1.0` users can explicitly set k3d version via `k3d-version` input e.g. `k3d-version: v5.2.2` otherwise k3d uses default version according to the mapping above.
+Starting from `k3d-action` `v1.4.0` users can also explicitly set [`k3s` image version](https://hub.docker.com/r/rancher/k3s/tags?page=1&ordering=last_updated) via [configuration](#config-file-support) or
+argument e.g.`--image docker.io/rancher/k3s:v1.20.4-k3s1` otherwise k3d uses default version according to the mapping above.
 
 For further k3s details see:
 - docker [rancher/k3s](https://hub.docker.com/r/rancher/k3s/tags?page=2&ordering=last_updated)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ AbsaOSS/k3d-action defines several input attributes and two outputs:
 ### Version mapping
 
 Implementation of additional features brings complexity and sometimes it may happen that extra feature is broken in special cases.
-To prevent potential issues, the `k3d` version is fixed according to the mapping below:
+Because of that, `k3d-action` has fixed default, tested against compatibility `k3d` version.
+Starting from k3d-action v2.1.0 users can explicitly set k3d version via `k3d-version` input e.g. `k3d-version: v5.2.2` otherwise k3d uses default version according to the mapping above.
 
 | k3d-action |   k3d   |           k3s           |
 |:----------:|:-------:|:-----------------------:|

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,9 @@ inputs:
   args:
     description: "(Optional) Additional arguments to k3d cluster. see: https://k3d.io/usage/commands/"
     required: false
+  k3d-version:
+    description: "(Optional) Version of k3d"
+    required: false
 runs:
   using: composite
   steps:
@@ -36,3 +39,4 @@ runs:
       env:
         CLUSTER_NAME: ${{ inputs.cluster-name }}
         ARGS: ${{ inputs.args }}
+        K3D_VERSION: ${{ inputs.k3d-version }}

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ CYAN=
 RED=
 NC=
 K3D_URL=https://raw.githubusercontent.com/rancher/k3d/main/install.sh
-K3D_VERSION=v5.1.0
+DEFAULT_K3D_VERSION=v5.1.0
 
 #######################
 #
@@ -44,6 +44,8 @@ usage(){
                         CLUSTER_NAME (Required) k3d cluster name.
 
                         ARGS (Optional) k3d arguments.
+
+                        K3D_VERSION (Optional) k3d version.
 EOF
 }
 
@@ -56,13 +58,14 @@ panic() {
 deploy(){
     local name=${CLUSTER_NAME}
     local arguments=${ARGS:-}
+    local k3dVersion=${K3D_VERSION:-${DEFAULT_K3D_VERSION}}
 
     if [[ -z "${CLUSTER_NAME}" ]]; then
       panic "CLUSTER_NAME must be set"
     fi
 
-    echo -e "${YELLOW}Downloading ${CYAN}k3d@${K3D_VERSION} ${NC}see: ${K3D_URL}"
-    curl --silent --fail ${K3D_URL} | TAG=${K3D_VERSION} bash
+    echo -e "${YELLOW}Downloading ${CYAN}k3d@${k3dVersion} ${NC}see: ${K3D_URL}"
+    curl --silent --fail ${K3D_URL} | TAG=${k3dVersion} bash
 
     echo -e "\existing_network${YELLOW}Deploy cluster ${CYAN}$name ${NC}"
     eval "k3d cluster create $name --wait $arguments"


### PR DESCRIPTION
Hi. I've prepared PR that allows user to specify concrete k3d version.
I think that it will be a good idea to not bump this plugin after each upgrade of k3d and just let users to do it on their own. WTYTAT?